### PR TITLE
fix: reimplement validate defaults

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -44,7 +44,31 @@ func (cv *CustomValidator) applyDefaultsRecursive(v reflect.Value) error {
 		return nil
 	}
 
-	if v.Kind() == reflect.Ptr {
+// 在 applyDefaultsRecursive 的 switch 中补充分支
+switch field.Kind() {
+case reflect.Struct, reflect.Ptr:
+    if err := cv.applyDefaultsRecursive(field); err != nil {
+        return err
+    }
+case reflect.Slice, reflect.Array:
+    for j := 0; j < field.Len(); j++ {
+        if err := cv.applyDefaultsRecursive(field.Index(j)); err != nil {
+            return err
+        }
+    }
+case reflect.Map:
+    // 仅处理 value
+    for _, k := range field.MapKeys() {
+        mv := field.MapIndex(k)
+        // MapIndex 返回不可设置的 Value，需要拷贝后递归并写回
+        vv := reflect.New(mv.Type()).Elem()
+        vv.Set(mv)
+        if err := cv.applyDefaultsRecursive(vv); err != nil {
+            return err
+        }
+        field.SetMapIndex(k, vv)
+    }
+}
 		if v.IsNil() {
 			return nil
 		}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,9 +1,13 @@
 package validate
 
 import (
+	"encoding"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
@@ -29,15 +33,24 @@ func (cv *CustomValidator) Validate(i any) error {
 }
 
 func (cv *CustomValidator) applyDefaults(i any) error {
-	v := reflect.ValueOf(i)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
+	if i == nil {
+		return nil
 	}
-
-	return cv.applyDefaultsRecursive(v)
+	return cv.applyDefaultsRecursive(reflect.ValueOf(i))
 }
 
 func (cv *CustomValidator) applyDefaultsRecursive(v reflect.Value) error {
+	if !v.IsValid() {
+		return nil
+	}
+
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
 	if v.Kind() != reflect.Struct {
 		return nil
 	}
@@ -51,51 +64,36 @@ func (cv *CustomValidator) applyDefaultsRecursive(v reflect.Value) error {
 			continue
 		}
 
-		if field.Kind() == reflect.Struct {
+		if err := cv.ensureFieldInitialized(field, fieldType); err != nil {
+			return err
+		}
+
+		if defVal := fieldType.Tag.Get("default"); defVal != "" && cv.isZeroValue(field) {
+			if err := cv.setFieldValue(field, defVal); err != nil {
+				return fmt.Errorf("field %s: %w", fieldType.Name, err)
+			}
+		}
+
+		switch field.Kind() {
+		case reflect.Struct, reflect.Ptr:
 			if err := cv.applyDefaultsRecursive(field); err != nil {
 				return err
 			}
-			continue
 		}
+	}
 
-		if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
-			// 检查该结构体或其字段是否有default tag
-			hasDefaultTag := false
-			if field.IsNil() {
-				// 检查结构体类型的字段是否有default tag
-				structType := field.Type().Elem()
-				for j := 0; j < structType.NumField(); j++ {
-					if structType.Field(j).Tag.Get("default") != "" {
-						hasDefaultTag = true
-						break
-					}
-				}
+	return nil
+}
 
-				// 只有当有default tag时才创建新实例
-				if hasDefaultTag {
-					field.Set(reflect.New(field.Type().Elem()))
-				} else {
-					continue // 没有default tag，保持为nil
-				}
-			}
+func (cv *CustomValidator) ensureFieldInitialized(field reflect.Value, fieldType reflect.StructField) error {
+	if field.Kind() != reflect.Ptr || !field.IsNil() {
+		return nil
+	}
 
-			if err := cv.applyDefaultsRecursive(field.Elem()); err != nil {
-				return err
-			}
-			continue
-		}
-
-		defaultValue := fieldType.Tag.Get("default")
-		if defaultValue == "" {
-			continue
-		}
-
-		if !cv.isZeroValue(field) {
-			continue
-		}
-
-		if err := cv.setFieldValue(field, defaultValue); err != nil {
-			return err
+	elemType := field.Type().Elem()
+	if elemType.Kind() == reflect.Struct {
+		if fieldType.Tag.Get("default") != "" || hasNestedDefault(elemType, nil) {
+			field.Set(reflect.New(elemType))
 		}
 	}
 
@@ -114,45 +112,149 @@ func (cv *CustomValidator) isZeroValue(field reflect.Value) bool {
 		return field.Float() == 0
 	case reflect.Bool:
 		return !field.Bool()
-	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface:
+	case reflect.Slice, reflect.Map, reflect.Interface, reflect.Ptr:
 		return field.IsNil()
 	default:
-		return false
+		return field.IsZero()
 	}
 }
 
 func (cv *CustomValidator) setFieldValue(field reflect.Value, value string) error {
+	if !field.CanSet() {
+		return nil
+	}
+
+	if field.Kind() != reflect.Interface && field.Kind() != reflect.Ptr {
+		if ok, err := setViaTextUnmarshaler(field, value); ok {
+			return err
+		}
+	}
+
 	switch field.Kind() {
 	case reflect.String:
 		field.SetString(value)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		if val, err := strconv.ParseInt(value, 10, 64); err == nil {
-			field.SetInt(val)
-		} else {
+		if field.Type().PkgPath() == "time" && field.Type().Name() == "Duration" {
+			d, err := time.ParseDuration(value)
+			if err != nil {
+				return err
+			}
+			field.SetInt(int64(d))
+			return nil
+		}
+		bitSize := field.Type().Bits()
+		if bitSize == 0 {
+			bitSize = 64
+		}
+		val, err := strconv.ParseInt(value, 10, bitSize)
+		if err != nil {
 			return err
 		}
+		field.SetInt(val)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		if val, err := strconv.ParseUint(value, 10, 64); err == nil {
-			field.SetUint(val)
-		} else {
+		bitSize := field.Type().Bits()
+		if bitSize == 0 {
+			bitSize = 64
+		}
+		val, err := strconv.ParseUint(value, 10, bitSize)
+		if err != nil {
 			return err
 		}
+		field.SetUint(val)
 	case reflect.Float32, reflect.Float64:
-		if val, err := strconv.ParseFloat(value, 64); err == nil {
-			field.SetFloat(val)
-		} else {
+		bitSize := field.Type().Bits()
+		if bitSize == 0 {
+			bitSize = 64
+		}
+		val, err := strconv.ParseFloat(value, bitSize)
+		if err != nil {
 			return err
 		}
+		field.SetFloat(val)
 	case reflect.Bool:
-		if val, err := strconv.ParseBool(value); err == nil {
-			field.SetBool(val)
-		} else {
+		val, err := strconv.ParseBool(value)
+		if err != nil {
 			return err
 		}
+		field.SetBool(val)
+	case reflect.Slice, reflect.Map, reflect.Array:
+		return setFromJSON(field, value)
+	case reflect.Struct:
+		return setFromJSON(field, value)
+	case reflect.Interface:
+		var v any
+		if err := json.Unmarshal([]byte(value), &v); err != nil {
+			field.Set(reflect.ValueOf(value))
+			return nil
+		}
+		field.Set(reflect.ValueOf(v))
+	case reflect.Ptr:
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return cv.setFieldValue(field.Elem(), value)
 	default:
+		return fmt.Errorf("unsupported kind %s for default tag", field.Kind())
+	}
+
+	return nil
+}
+
+func setFromJSON(field reflect.Value, raw string) error {
+	if raw == "" {
 		return nil
 	}
+
+	target := reflect.New(field.Type())
+	if err := json.Unmarshal([]byte(raw), target.Interface()); err != nil {
+		return err
+	}
+	field.Set(target.Elem())
 	return nil
+}
+
+func setViaTextUnmarshaler(field reflect.Value, value string) (bool, error) {
+	if field.CanAddr() {
+		if unmarshaler, ok := field.Addr().Interface().(encoding.TextUnmarshaler); ok {
+			return true, unmarshaler.UnmarshalText([]byte(value))
+		}
+	}
+	return false, nil
+}
+
+func hasNestedDefault(t reflect.Type, visited map[reflect.Type]struct{}) bool {
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+
+	if visited == nil {
+		visited = make(map[reflect.Type]struct{})
+	}
+
+	if _, ok := visited[t]; ok {
+		return false
+	}
+	visited[t] = struct{}{}
+
+	for i := 0; i < t.NumField(); i++ {
+		ft := t.Field(i)
+		if ft.Tag.Get("default") != "" {
+			return true
+		}
+
+		switch ft.Type.Kind() {
+		case reflect.Struct:
+			if hasNestedDefault(ft.Type, visited) {
+				return true
+			}
+		case reflect.Ptr:
+			if ft.Type.Elem().Kind() == reflect.Struct && hasNestedDefault(ft.Type.Elem(), visited) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (cv *CustomValidator) ValidateWithDefaults(i any) error {
@@ -161,6 +263,9 @@ func (cv *CustomValidator) ValidateWithDefaults(i any) error {
 
 func (cv *CustomValidator) SetDefault(i any, fieldName, defaultValue string) error {
 	v := reflect.ValueOf(i)
+	if !v.IsValid() {
+		return echo.NewHTTPError(http.StatusBadRequest, "参数无效")
+	}
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
@@ -174,5 +279,12 @@ func (cv *CustomValidator) SetDefault(i any, fieldName, defaultValue string) err
 		return echo.NewHTTPError(http.StatusBadRequest, "字段不可设置: "+fieldName)
 	}
 
-	return cv.setFieldValue(field, defaultValue)
+	if field.Kind() == reflect.Ptr && field.IsNil() {
+		field.Set(reflect.New(field.Type().Elem()))
+	}
+
+	if err := cv.setFieldValue(field, defaultValue); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "设置默认值失败: "+err.Error())
+	}
+	return nil
 }

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -2,7 +2,12 @@ package validate
 
 import (
 	"testing"
+	"time"
 )
+
+type pointerField struct {
+	Count *int
+}
 
 func TestCustomValidator_ExampleUsage(t *testing.T) {
 	TestValidator()
@@ -58,6 +63,7 @@ func TestCustomValidator_SetDefault(t *testing.T) {
 		fieldName    string
 		defaultValue string
 		wantErr      bool
+		check        func(*testing.T, any)
 	}{
 		{
 			name:         "设置字符串默认值",
@@ -81,6 +87,19 @@ func TestCustomValidator_SetDefault(t *testing.T) {
 			wantErr:      false,
 		},
 		{
+			name:         "设置指针默认值",
+			input:        &pointerField{},
+			fieldName:    "Count",
+			defaultValue: "12",
+			wantErr:      false,
+			check: func(t *testing.T, input any) {
+				pf := input.(*pointerField)
+				if pf.Count == nil || *pf.Count != 12 {
+					t.Fatalf("Count default value = %v, want %v", pf.Count, 12)
+				}
+			},
+		},
+		{
 			name:         "字段不存在",
 			input:        &UserRequest{},
 			fieldName:    "NonExistentField",
@@ -94,6 +113,10 @@ func TestCustomValidator_SetDefault(t *testing.T) {
 			err := validator.SetDefault(tt.input, tt.fieldName, tt.defaultValue)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CustomValidator.SetDefault() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil && tt.check != nil {
+				tt.check(t, tt.input)
 			}
 		})
 	}
@@ -184,5 +207,47 @@ func TestCustomValidator_NestedStruct(t *testing.T) {
 		if productReq.Contact.Website != "https://example.com" {
 			t.Errorf("Contact.Website default value = %v, want %v", productReq.Contact.Website, "https://example.com")
 		}
+	}
+}
+
+func TestCustomValidator_PointerAndCompositeDefaults(t *testing.T) {
+	validator := NewCustomValidator()
+
+	type complexDefaults struct {
+		Enabled *bool             `default:"true"`
+		Limit   *int              `default:"99"`
+		Tags    []string          `default:"[\"base\",\"beta\"]"`
+		Meta    map[string]string `default:"{\"env\":\"dev\"}"`
+		Payload any               `default:"{\"role\":\"user\"}"`
+		Timeout time.Duration     `default:"5s"`
+	}
+
+	req := &complexDefaults{}
+	if err := validator.applyDefaults(req); err != nil {
+		t.Fatalf("applyDefaults() error = %v", err)
+	}
+
+	if req.Enabled == nil || !*req.Enabled {
+		t.Fatalf("Enabled default value = %v, want %v", req.Enabled, true)
+	}
+	if req.Limit == nil || *req.Limit != 99 {
+		t.Fatalf("Limit default value = %v, want %v", req.Limit, 99)
+	}
+	if len(req.Tags) != 2 {
+		t.Fatalf("Tags default length = %d, want %d", len(req.Tags), 2)
+	}
+	if req.Meta == nil || req.Meta["env"] != "dev" {
+		t.Fatalf("Meta default value = %v, want env=dev", req.Meta)
+	}
+	if req.Timeout != 5*time.Second {
+		t.Fatalf("Timeout default value = %v, want %v", req.Timeout, 5*time.Second)
+	}
+
+	payload, ok := req.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("Payload type = %T, want map[string]any", req.Payload)
+	}
+	if payload["role"] != "user" {
+		t.Fatalf("Payload role = %v, want %v", payload["role"], "user")
 	}
 }


### PR DESCRIPTION
## Summary
- rework default tag application to cover struct pointers, slices/maps, and custom types
- extend SetDefault to pointer fields and surface clearer errors
- add regression tests for pointer/composite defaults
