### PR TITLE
fix: 修复 default tag 对 bool 类型的处理

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -58,11 +58,24 @@ func (cv *CustomValidator) applyDefaultsRecursive(v reflect.Value) error {
 			continue
 		}
 
-		if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
-			// 检查该结构体或其字段是否有default tag
+		if field.Kind() == reflect.Ptr {
+			elemKind := field.Type().Elem().Kind()
+
+			// 处理基础类型指针 (*bool, *int, *string 等)
+			if elemKind != reflect.Struct {
+				defaultValue := fieldType.Tag.Get("default")
+				if defaultValue != "" && field.IsNil() {
+					field.Set(reflect.New(field.Type().Elem()))
+					if err := cv.setFieldValue(field.Elem(), defaultValue); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			// 处理结构体指针
 			hasDefaultTag := false
 			if field.IsNil() {
-				// 检查结构体类型的字段是否有default tag
 				structType := field.Type().Elem()
 				for j := 0; j < structType.NumField(); j++ {
 					if structType.Field(j).Tag.Get("default") != "" {
@@ -71,11 +84,10 @@ func (cv *CustomValidator) applyDefaultsRecursive(v reflect.Value) error {
 					}
 				}
 
-				// 只有当有default tag时才创建新实例
 				if hasDefaultTag {
 					field.Set(reflect.New(field.Type().Elem()))
 				} else {
-					continue // 没有default tag，保持为nil
+					continue
 				}
 			}
 
@@ -113,7 +125,7 @@ func (cv *CustomValidator) isZeroValue(field reflect.Value) bool {
 	case reflect.Float32, reflect.Float64:
 		return field.Float() == 0
 	case reflect.Bool:
-		return !field.Bool()
+		return false // bool 类型无法区分零值和未设置，建议使用 *bool
 	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface:
 		return field.IsNil()
 	default:

--- a/validate/validate_example.go
+++ b/validate/validate_example.go
@@ -10,7 +10,7 @@ type UserRequest struct {
 	Name     string `json:"name" validate:"required" default:"匿名用户"`
 	Age      int    `json:"age" validate:"gte=0,lte=150" default:"18"`
 	Email    string `json:"email" validate:"email" default:"user@example.com"`
-	IsActive bool   `json:"is_active" default:"true"`
+	IsActive *bool  `json:"is_active" default:"true"`
 	Page     int    `json:"page" validate:"gte=1" default:"1"`
 	Size     int    `json:"size" validate:"gte=1,lte=100" default:"10"`
 }
@@ -36,7 +36,7 @@ type ProductRequest struct {
 	Price       float64      `json:"price" validate:"gte=0" default:"0.0"`
 	Description string       `json:"description" default:"暂无描述"`
 	Category    string       `json:"category" default:"未分类"`
-	InStock     bool         `json:"in_stock" default:"false"`
+	InStock     *bool        `json:"in_stock" default:"false"`
 	Address     Address      `json:"address"` // 嵌套结构体
 	Contact     *ContactInfo `json:"contact"` // 嵌套结构体指针
 }

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -119,7 +119,7 @@ func TestCustomValidator_applyDefaults(t *testing.T) {
 	if userReq.Email != "user@example.com" {
 		t.Errorf("Email default value = %v, want %v", userReq.Email, "user@example.com")
 	}
-	if !userReq.IsActive {
+	if userReq.IsActive == nil || !*userReq.IsActive {
 		t.Errorf("IsActive default value = %v, want %v", userReq.IsActive, true)
 	}
 	if userReq.Page != 1 {
@@ -153,7 +153,7 @@ func TestCustomValidator_NestedStruct(t *testing.T) {
 	if productReq.Category != "未分类" {
 		t.Errorf("Category default value = %v, want %v", productReq.Category, "未分类")
 	}
-	if productReq.InStock {
+	if productReq.InStock == nil || *productReq.InStock {
 		t.Errorf("InStock default value = %v, want %v", productReq.InStock, false)
 	}
 


### PR DESCRIPTION
- bool 类型无法区分零值和未设置，改用 *bool 指针类型
- 新增对基础类型指针 (*bool, *int 等) 的 default tag 支持
- 只有 nil 时才应用默认值，用户显式传入 false 会被保留