### PR TITLE
支持从 cookie 读取 i18n 语言

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 
@@ -51,8 +52,25 @@ func (c *Context) Page() *Pagination {
 	return c.page
 }
 
+func (c *Context) Lang() string {
+	if cookie, err := c.Cookie("language"); err == nil {
+		if lang := normalizeLang(cookie.Value); lang != "" {
+			return lang
+		}
+	}
+	return normalizeLang(c.Request().Header.Get("Accept-Language"))
+}
+
+func normalizeLang(lang string) string {
+	lang = strings.TrimSpace(lang)
+	if strings.EqualFold(lang, "cn") {
+		return "zh"
+	}
+	return lang
+}
+
 func (c *Context) ErrMsg(id ErrorID, param map[string]any) string {
-	return c.locale.Message(c.Request().Header.Get("Accept-Language"), string(id), param)
+	return c.locale.Message(c.Lang(), string(id), param)
 }
 
 func (c *Context) Failed(status, code int, id ErrorID, err error) error {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,0 +1,80 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/GoYoko/web/locale"
+)
+
+func newTestContext(req *http.Request) *Context {
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	return &Context{
+		Context: e.NewContext(req, rec),
+		locale:  locale.NewLocalizer(),
+	}
+}
+
+func TestContextLang(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerLang string
+		cookieLang string
+		want       string
+	}{
+		{
+			name:       "cookie language has priority",
+			headerLang: "zh",
+			cookieLang: "en",
+			want:       "en",
+		},
+		{
+			name:       "fallback to accept language when cookie is missing",
+			headerLang: "en",
+			want:       "en",
+		},
+		{
+			name:       "maps cn to zh",
+			cookieLang: "cn",
+			want:       "zh",
+		},
+		{
+			name:       "fallback to accept language when cookie is blank",
+			headerLang: "en",
+			cookieLang: "  ",
+			want:       "en",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.headerLang != "" {
+				req.Header.Set("Accept-Language", tt.headerLang)
+			}
+			if tt.cookieLang != "" {
+				req.AddCookie(&http.Cookie{Name: "language", Value: tt.cookieLang})
+			}
+
+			ctx := newTestContext(req)
+			if got := ctx.Lang(); got != tt.want {
+				t.Fatalf("Lang() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContextErrMsgUsesCookieLanguage(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Language", "zh")
+	req.AddCookie(&http.Cookie{Name: "language", Value: "en"})
+
+	ctx := newTestContext(req)
+	if got := ctx.ErrMsg(ErrBindParams, nil); got != "Invalid parameters" {
+		t.Fatalf("ErrMsg() = %q, want %q", got, "Invalid parameters")
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 Context.Lang()，优先读取 language cookie
- cookie 缺失或为空时回退到 Accept-Language
- 增加 cn 到 zh 的语言映射和对应测试

## Test Plan
- go test ./...